### PR TITLE
eslint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,5 +14,7 @@ module.exports = {
   plugins: [
   ],
   // add your custom rules here
-  rules: {}
+  rules: {
+    'vue/multi-word-component-names': 'off'
+  }
 }


### PR DESCRIPTION
Turn off multi-word-component-names rule